### PR TITLE
Convert module roles to mutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Mutable parameters:
 ### Signing the Agreement and Claiming the Community Hat (Anyone)
 
 Anyone can make themselves eligible for the hat by signing the agreement. There are two options of doing so:
+
 1. Signing the agreement and claiming the hat, in one transaction. Doing so involves calling the `signAgreementAndClaimHat` function. The function receives as an input a [Multi Claims Hatter](https://github.com/Hats-Protocol/multi-claims-hatter) instance, which will be used for claiming the hat.
 
 2. Only signing the agreement, using the `signAgreement` function.

--- a/README.md
+++ b/README.md
@@ -38,19 +38,19 @@ Active community members can sign the new agreement by calling the `signAgreemen
 
 ### Publishing a New Agreement (Owner Only)
 
-The wearer of the `OWNER_HAT` can publish a new agreement by calling the `setAgreement()` function. Just like intialization, this involves passing both the `agreement` and `grace` parameters. This action also increments the `currentAgreementId`.
+The wearer of the `ownerHat` can publish a new agreement by calling the `setAgreement()` function. Just like initialization, this involves passing both the `agreement` and `grace` parameters. This action also increments the `currentAgreementId`.
 
 Once a new agreement is set, the grace period begins.
 
 ### Revoking a Community Member's Hat (Arbitrator Only)
 
-The wearer of the `ARBITRATOR_HAT` can revoke a community member's hat by calling the `revoke()` function. This function takes a single parameter, `wearer`, which is the address of the community member whose hat is being revoked.
+The wearer of the `arbitratorHat` can revoke a community member's hat by calling the `revoke()` function. This function takes a single parameter, `wearer`, which is the address of the community member whose hat is being revoked.
 
 When a hat is revoked, the hat is burned and the member is placed in badStanding within Hats Protocol. This means that the member is no longer eligible to wear the community hat and cannot re-claim the community hat until the arbitrator places them back in good standing.
 
 ### Forgiving a Community Member (Arbitrator Only)
 
-If an individual's community hat has been revoked, then they are in bad standing. If the wearer of the `ARBITRATOR_HAT` believes that the individual has made up for the behavior that led to the revocation, they can call the `forgive()` function. This places the individual back in good standing, enabling them to claim the community hat again if they so choose.
+If an individual's community hat has been revoked, then they are in bad standing. If the wearer of the `arbitratorHat` believes that the individual has made up for the behavior that led to the revocation, they can call the `forgive()` function. This places the individual back in good standing, enabling them to claim the community hat again if they so choose.
 
 ### Hat Eligibility
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ The module is deployed and initialized by the organization. As a Hats Protocol m
 Immutable parameters:
 
 - `hatId` — The hat id for the community hat
-- `OWNER_HAT` — The hat id for the owner hat, i.e., the hat whose wearer is authorized to publish new agreements
-- `ARBITRATOR_HAT` — The hat id for the arbitrator hat, i.e. the hat whose wearer is authorized to revoke the community hat from a given community member
 
 Mutable parameters:
 
+- `ownerHat` — The hat id for the owner hat, i.e., the hat whose wearer is authorized to publish new agreements
+- `arbitratorHat` — The hat id for the arbitrator hat, i.e. the hat whose wearer is authorized to revoke the community hat from a given community member
 - `agreement` — The initial agreement, in the form of a hash. This is typically a CID pointing to a file containing the plaintext of the agreement.
 
 ### Signing the Agreement and Claiming the Community Hat (Anyone)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The Agreement Eligibility is a [Hats Protocol](https://github.com/Hats-Protocol/
 
 When an individual signs the agreement, they also receive a hat that grants them access to the community. If a new agreement is published, community members must sign the new agreement to continue to wear the hat and remain a member of the community.
 
+## Functionality and Usage
+
 ### Deployment and Initialization
 
 The module is deployed and initialized by the organization. As a Hats Protocol module, it can be deployed via the [Hats Module Factory](https://github.com/Hats-Protocol/hats-module#hatsmodulefactory). When the contract is deployed, the organization must specify the following parameters:

--- a/src/AgreementEligibility.sol
+++ b/src/AgreementEligibility.sol
@@ -9,9 +9,9 @@ import { MultiClaimsHatter } from "multi-claims-hatter/MultiClaimsHatter.sol";
                             CUSTOM ERRORS
 //////////////////////////////////////////////////////////////*/
 
-/// @dev Thrown when the caller does not wear the `OWNER_HAT`
+/// @dev Thrown when the caller does not wear the `ownerHat`
 error AgreementEligibility_NotOwner();
-/// @dev Thrown when the caller does not wear the `ARBITRATOR_HAT`
+/// @dev Thrown when the caller does not wear the `arbitratorHat`
 error AgreementEligibility_NotArbitrator();
 /// @dev Thrown when the hat is not mutable
 error AgreementEligibility_HatNotMutable();
@@ -195,7 +195,7 @@ contract AgreementEligibility is HatsEligibilityModule {
 
   /**
    * @notice Set a new agreement, with a grace period
-   * @dev Only callable by a wearer of the `OWNER_HAT`
+   * @dev Only callable by a wearer of the `ownerHat`
    * @param _agreement The new agreement, as a hash of the agreement plaintext (likely a CID)
    * @param _grace The new grace period
    */
@@ -211,7 +211,7 @@ contract AgreementEligibility is HatsEligibilityModule {
 
   /**
    * @notice Revoke the `_wearer`'s hat and place them in bad standing
-   * @dev Only callable by a wearer of the `ARBITRATOR_HAT`
+   * @dev Only callable by a wearer of the `arbitratorHat`
    * @param _wearer The address of the wearer from whom to revoke the hat
    */
   function revoke(address _wearer) public onlyArbitrator {
@@ -230,7 +230,7 @@ contract AgreementEligibility is HatsEligibilityModule {
 
   /**
    * @notice Forgive the `_wearer`'s bad standing, allowing them to claim the hat again
-   * @dev Only callable by a wearer of the `ARBITRATOR_HAT`
+   * @dev Only callable by a wearer of the `arbitratorHat`
    * @param _wearer The address of the wearer to forgive
    */
   function forgive(address _wearer) public onlyArbitrator {
@@ -252,7 +252,7 @@ contract AgreementEligibility is HatsEligibilityModule {
 
   /**
    * @notice Set a new arbitrator hat
-   * @dev Only callable by a wearer of the current arbitratorHat, and only if the target hat is mutable
+   * @dev Only callable by a wearer of the current ownerHat, and only if the target hat is mutable
    * @param _newArbitratorHat The new arbitrator hat
    */
   function setArbitratorHat(uint256 _newArbitratorHat) public onlyOwner hatIsMutable {
@@ -292,13 +292,13 @@ contract AgreementEligibility is HatsEligibilityModule {
                             MODIFERS
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Reverts if the caller is not wearing the OWNER_HAT.
+  /// @notice Reverts if the caller is not wearing the ownerHat.
   modifier onlyOwner() {
     if (!HATS().isWearerOfHat(msg.sender, ownerHat)) revert AgreementEligibility_NotOwner();
     _;
   }
 
-  /// @notice Reverts if the caller is not wearing the ARBITRATOR_HAT.
+  /// @notice Reverts if the caller is not wearing the arbitratorHat.
   modifier onlyArbitrator() {
     if (!HATS().isWearerOfHat(msg.sender, arbitratorHat)) revert AgreementEligibility_NotArbitrator();
     _;


### PR DESCRIPTION
Converts ownerHat and arbitratorHat from immutable "constants" to mutable storage values. 

The reason to do this is that this module is stateful, which adds friction to migrating to a new instance in order to update owner or arbitrator roles.

There are two primary benefits of immutable config on modules
1. simple to understand when/how they can be updated, ie by an admin of the hat as long as the hat is mutable
2. some gas savings by using immutable values instead of storage reads

We can get the benefits of (1) in a mutable scenario by constraining changes to when the hat is mutable.