### PR TITLE
add batch `revoke` and `forgive` functions

### DIFF
--- a/script/AgreementEligibility.s.sol
+++ b/script/AgreementEligibility.s.sol
@@ -36,9 +36,9 @@ contract Deploy is Script {
   // forge script script/AgreementEligibility.s.sol:Deploy -f ethereum --broadcast --verify
 
   /* 
-  forge verify-contract --chain-id 11155111 --num-of-optimizations 1000000 --watch 
+  forge verify-contract --chain-id 11155111 --num-of-optimizations 1000000 --watch \
   --constructor-args $(cast abi-encode "constructor(string)" "0.4.0" ) \
-  --compiler-version v0.8.19 0xeC61e2Fca88BBa42B7e251A1A9738d9ad001B08B \
+  --compiler-version v0.8.19 0x4F10B9e99ce11f081652646f4b192ed1b812D5Bb \
   src/AgreementEligibility.sol:AgreementEligibility --etherscan-api-key $ETHERSCAN_KEY 
   */
 }
@@ -49,7 +49,7 @@ contract DeployInstance is Script {
 
   // default values
   bool internal _verbose = true;
-  address internal _implementation = 0xeC61e2Fca88BBa42B7e251A1A9738d9ad001B08B; // 0.4.0
+  address internal _implementation = 0x4F10B9e99ce11f081652646f4b192ed1b812D5Bb; // 0.4.0
 
   uint256 internal _saltNonce = 1;
   uint256 internal _hatId = 0x000000380001000a000000000000000000000000000000000000000000000000; // 56.1.10

--- a/script/AgreementEligibility.s.sol
+++ b/script/AgreementEligibility.s.sol
@@ -10,7 +10,7 @@ contract Deploy is Script {
 
   // default values
   bool private verbose = true;
-  string private version = "0.3.0"; // increment with each deployment
+  string private version = "0.4.0"; // increment with each deployment
 
   /// @notice Override default values, if desired
   function prepare(bool _verbose, string memory _version) public {

--- a/src/AgreementEligibility.sol
+++ b/src/AgreementEligibility.sol
@@ -215,7 +215,7 @@ contract AgreementEligibility is HatsEligibilityModule {
    * @param _wearer The address of the wearer from whom to revoke the hat
    */
   function revoke(address _wearer) public onlyArbitrator {
-    _revoke(_wearer);
+    _revoke(_wearer, hatId());
   }
 
   /**
@@ -224,8 +224,9 @@ contract AgreementEligibility is HatsEligibilityModule {
    * @param _wearers The addresses of the wearers from whom to revoke the hats
    */
   function revoke(address[] calldata _wearers) public onlyArbitrator {
+    uint256 hatId = hatId();
     for (uint256 i; i < _wearers.length;) {
-      _revoke(_wearers[i]);
+      _revoke(_wearers[i], hatId);
 
       unchecked {
         ++i;
@@ -239,7 +240,7 @@ contract AgreementEligibility is HatsEligibilityModule {
    * @param _wearer The address of the wearer to forgive
    */
   function forgive(address _wearer) public onlyArbitrator {
-    _forgive(_wearer);
+    _forgive(_wearer, hatId());
   }
 
   /**
@@ -248,8 +249,9 @@ contract AgreementEligibility is HatsEligibilityModule {
    * @param _wearers The addresses of the wearers to forgive
    */
   function forgive(address[] calldata _wearers) public onlyArbitrator {
+    uint256 hatId = hatId();
     for (uint256 i; i < _wearers.length;) {
-      _forgive(_wearers[i]);
+      _forgive(_wearers[i], hatId);
 
       unchecked {
         ++i;
@@ -306,12 +308,12 @@ contract AgreementEligibility is HatsEligibilityModule {
 
   /// @dev Revoke a wearer's hat and set their standing to false in Hats.sol
   /// Unsafe. Does not check that the caller is wearing the arbitratorHat.
-  function _revoke(address _wearer) internal {
+  function _revoke(address _wearer, uint256 _hatId) internal {
     _badStandings[_wearer] = true;
 
     // revoke _wearer's hat and set their standing to false in Hats.sol. We use the pull pattern (checkHatWearerStatus)
     // rather than the push pattern (setHatWearerStatus) for compatibility with module chains.
-    HATS().checkHatWearerStatus(hatId(), _wearer);
+    HATS().checkHatWearerStatus(_hatId, _wearer);
 
     /**
      * @dev Hats.sol will emit the following events:
@@ -322,12 +324,12 @@ contract AgreementEligibility is HatsEligibilityModule {
 
   /// @dev Forgive a wearer and set their standing to true in Hats.sol
   /// Unsafe. Does not check that the caller is wearing the arbitratorHat.
-  function _forgive(address _wearer) internal {
+  function _forgive(address _wearer, uint256 _hatId) internal {
     _badStandings[_wearer] = false;
 
     // return the wearer to good standing in Hats.sol. We use the pull pattern (checkHatWearerStatus) rather than the
     // push pattern (setHatWearerStatus) for compatibility with module chains.
-    HATS().checkHatWearerStatus(hatId(), _wearer);
+    HATS().checkHatWearerStatus(_hatId, _wearer);
 
     /// @dev Hats.sol will emit a Hats.WearerStandingChanged event
   }

--- a/src/AgreementEligibility.sol
+++ b/src/AgreementEligibility.sol
@@ -36,6 +36,12 @@ contract AgreementEligibility is HatsEligibilityModule {
   event AgreementEligibility_OwnerHatSet(uint256 newOwnerHat);
   /// @dev Emitted when the `arbitratorHat` is set
   event AgreementEligibility_ArbitratorHatSet(uint256 newArbitratorHat);
+  /// @dev Emitted when a wearer's hat is revoked and placed in bad standing
+  event AgreementEligibility_Revoked(address wearer);
+  event AgreementEligibility_Revoked(address[] wearers);
+  /// @dev Emitted when a wearer is forgiven and their standing restored
+  event AgreementEligibility_Forgiven(address wearer);
+  event AgreementEligibility_Forgiven(address[] wearers);
 
   /*//////////////////////////////////////////////////////////////
                               CONSTANTS
@@ -216,6 +222,7 @@ contract AgreementEligibility is HatsEligibilityModule {
    */
   function revoke(address _wearer) public onlyArbitrator {
     _revoke(_wearer, hatId());
+    emit AgreementEligibility_Revoked(_wearer);
   }
 
   /**
@@ -232,6 +239,8 @@ contract AgreementEligibility is HatsEligibilityModule {
         ++i;
       }
     }
+
+    emit AgreementEligibility_Revoked(_wearers);
   }
 
   /**
@@ -241,6 +250,7 @@ contract AgreementEligibility is HatsEligibilityModule {
    */
   function forgive(address _wearer) public onlyArbitrator {
     _forgive(_wearer, hatId());
+    emit AgreementEligibility_Forgiven(_wearer);
   }
 
   /**
@@ -257,6 +267,8 @@ contract AgreementEligibility is HatsEligibilityModule {
         ++i;
       }
     }
+
+    emit AgreementEligibility_Forgiven(_wearers);
   }
 
   /**

--- a/test/AgreementEligibility.t.sol
+++ b/test/AgreementEligibility.t.sol
@@ -36,6 +36,10 @@ contract AgreementEligibilityTest is Deploy, Test {
   event AgreementEligibility_AgreementSet(string agreement, uint256 grace);
   event AgreementEligibility_OwnerHatSet(uint256 newOwnerHat);
   event AgreementEligibility_ArbitratorHatSet(uint256 newArbitratorHat);
+  event AgreementEligibility_Revoked(address wearer);
+  event AgreementEligibility_Revoked(address[] wearers);
+  event AgreementEligibility_Forgiven(address wearer);
+  event AgreementEligibility_Forgiven(address[] wearers);
 
   function setUp() public virtual {
     // create and activate a fork, at BLOCK_NUMBER
@@ -350,6 +354,9 @@ contract Revoke is WithInstanceTest {
     instance.signAgreementAndClaimHat(address(claimsHatter));
 
     // revoke
+    vm.expectEmit();
+    emit AgreementEligibility_Revoked(claimer1);
+
     vm.prank(arbitrator);
     instance.revoke(claimer1);
 
@@ -390,6 +397,9 @@ contract RevokeMultiple is WithInstanceTest {
     }
 
     // revoke all the claimers
+    vm.expectEmit();
+    emit AgreementEligibility_Revoked(claimers);
+
     vm.prank(arbitrator);
     instance.revoke(claimers);
 
@@ -436,6 +446,9 @@ contract Forgive is WithInstanceTest {
     assertFalse(HATS.isWearerOfHat(claimer1, claimableHat));
 
     // forgive
+    vm.expectEmit();
+    emit AgreementEligibility_Forgiven(claimer1);
+
     vm.prank(arbitrator);
     instance.forgive(claimer1);
 
@@ -483,6 +496,9 @@ contract ForgiveMultiple is WithInstanceTest {
     instance.revoke(claimers);
 
     // forgive all the claimers
+    vm.expectEmit();
+    emit AgreementEligibility_Forgiven(claimers);
+
     vm.prank(arbitrator);
     instance.forgive(claimers);
 

--- a/test/AgreementEligibility.t.sol
+++ b/test/AgreementEligibility.t.sol
@@ -10,7 +10,7 @@ import {
   AgreementEligibility_NotArbitrator,
   AgreementEligibility_HatNotMutable
 } from "../src/AgreementEligibility.sol";
-import { Deploy } from "../script/AgreementEligibility.s.sol";
+import { Deploy, DeployInstance } from "../script/AgreementEligibility.s.sol";
 import {
   IHats,
   HatsModuleFactory,
@@ -88,14 +88,12 @@ contract WithInstanceTest is AgreementEligibilityTest {
     uint256 _arbitratorHat,
     string memory _agreement
   ) public returns (AgreementEligibility) {
-    // encode the other immutable args as packed bytes
-    otherImmutableArgs = abi.encodePacked();
-    // encoded the initData as unpacked bytes
-    initData = abi.encode(_ownerHat, _arbitratorHat, _agreement);
-    // deploy the instance
-    return AgreementEligibility(
-      deployModuleInstance(factory, address(implementation), _claimableHat, otherImmutableArgs, initData, SALT_NONCE)
+    // create DeployInstance script and use it here
+    DeployInstance instanceDeployer = new DeployInstance();
+    instanceDeployer.prepare(
+      false, address(implementation), _claimableHat, _ownerHat, _arbitratorHat, _agreement, SALT_NONCE
     );
+    return instanceDeployer.run();
   }
 
   function deployMultiClaimsHatterInstance(


### PR DESCRIPTION
This PR adds batch versions of the `revoke` and `forgive` functions. The new functions overload the same function names but take arrays of addresses instead of a single address.